### PR TITLE
Allow Multiple Embedded Collections

### DIFF
--- a/backend/drizzle/0013_marketplace_defaultcollection.sql
+++ b/backend/drizzle/0013_marketplace_defaultcollection.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "collections" ADD COLUMN "defaultForNewExercises" boolean DEFAULT false NOT NULL;

--- a/backend/drizzle/meta/0013_snapshot.json
+++ b/backend/drizzle/meta/0013_snapshot.json
@@ -1,0 +1,1096 @@
+{
+    "id": "9628b6dc-9665-4cbd-a4a0-48a1215d0ab5",
+    "prevId": "3f916a7a-76fe-4cdd-a8bd-c33daa4bda3b",
+    "version": "7",
+    "dialect": "postgresql",
+    "tables": {
+        "public.access_key": {
+            "name": "access_key",
+            "schema": "",
+            "columns": {
+                "key": {
+                    "name": "key",
+                    "type": "varchar",
+                    "primaryKey": true,
+                    "notNull": true
+                }
+            },
+            "indexes": {},
+            "foreignKeys": {},
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.action_entity": {
+            "name": "action_entity",
+            "schema": "",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "uuid",
+                    "primaryKey": true,
+                    "notNull": true
+                },
+                "emitterId": {
+                    "name": "emitterId",
+                    "type": "uuid",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "index": {
+                    "name": "index",
+                    "type": "bigint",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "actionString": {
+                    "name": "actionString",
+                    "type": "json",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "exerciseId": {
+                    "name": "exerciseId",
+                    "type": "uuid",
+                    "primaryKey": false,
+                    "notNull": true
+                }
+            },
+            "indexes": {},
+            "foreignKeys": {
+                "FK_180a58767f06b503216ba2b0982": {
+                    "name": "FK_180a58767f06b503216ba2b0982",
+                    "tableFrom": "action_entity",
+                    "tableTo": "exercise_entity",
+                    "columnsFrom": ["exerciseId"],
+                    "columnsTo": ["id"],
+                    "onDelete": "cascade",
+                    "onUpdate": "cascade"
+                }
+            },
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {
+                "action_entity_index_exerciseId_unique": {
+                    "name": "action_entity_index_exerciseId_unique",
+                    "nullsNotDistinct": false,
+                    "columns": ["index", "exerciseId"]
+                }
+            },
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.collection_dependency_mapping": {
+            "name": "collection_dependency_mapping",
+            "schema": "",
+            "columns": {
+                "dependentCollectionEntityId": {
+                    "name": "dependentCollectionEntityId",
+                    "type": "varchar",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "dependentCollectionVersionId": {
+                    "name": "dependentCollectionVersionId",
+                    "type": "varchar",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "collectionEntityId": {
+                    "name": "collectionEntityId",
+                    "type": "varchar",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "collectionVersionId": {
+                    "name": "collectionVersionId",
+                    "type": "varchar",
+                    "primaryKey": false,
+                    "notNull": true
+                }
+            },
+            "indexes": {},
+            "foreignKeys": {
+                "collection_dependency_mapping_dependentCollectionVersionId_collections_versionId_fk": {
+                    "name": "collection_dependency_mapping_dependentCollectionVersionId_collections_versionId_fk",
+                    "tableFrom": "collection_dependency_mapping",
+                    "tableTo": "collections",
+                    "columnsFrom": ["dependentCollectionVersionId"],
+                    "columnsTo": ["versionId"],
+                    "onDelete": "cascade",
+                    "onUpdate": "no action"
+                },
+                "collection_dependency_mapping_collectionVersionId_collections_versionId_fk": {
+                    "name": "collection_dependency_mapping_collectionVersionId_collections_versionId_fk",
+                    "tableFrom": "collection_dependency_mapping",
+                    "tableTo": "collections",
+                    "columnsFrom": ["collectionVersionId"],
+                    "columnsTo": ["versionId"],
+                    "onDelete": "cascade",
+                    "onUpdate": "no action"
+                }
+            },
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {
+                "unique_collection_dependency": {
+                    "name": "unique_collection_dependency",
+                    "nullsNotDistinct": false,
+                    "columns": [
+                        "dependentCollectionVersionId",
+                        "collectionEntityId"
+                    ]
+                }
+            },
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.collection_join_codes": {
+            "name": "collection_join_codes",
+            "schema": "",
+            "columns": {
+                "code": {
+                    "name": "code",
+                    "type": "varchar",
+                    "primaryKey": true,
+                    "notNull": true
+                },
+                "collection": {
+                    "name": "collection",
+                    "type": "varchar",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "expiresAt": {
+                    "name": "expiresAt",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": true
+                }
+            },
+            "indexes": {},
+            "foreignKeys": {},
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.collection_organisation_mapping": {
+            "name": "collection_organisation_mapping",
+            "schema": "",
+            "columns": {
+                "collection": {
+                    "name": "collection",
+                    "type": "varchar",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "organisationId": {
+                    "name": "organisationId",
+                    "type": "uuid",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "owner": {
+                    "name": "owner",
+                    "type": "boolean",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": false
+                }
+            },
+            "indexes": {},
+            "foreignKeys": {
+                "collection_organisation_mapping_organisationId_organisation_id_fk": {
+                    "name": "collection_organisation_mapping_organisationId_organisation_id_fk",
+                    "tableFrom": "collection_organisation_mapping",
+                    "tableTo": "organisation",
+                    "columnsFrom": ["organisationId"],
+                    "columnsTo": ["id"],
+                    "onDelete": "cascade",
+                    "onUpdate": "no action"
+                }
+            },
+            "compositePrimaryKeys": {
+                "collection_organisation_mapping_collection_organisationId_pk": {
+                    "name": "collection_organisation_mapping_collection_organisationId_pk",
+                    "columns": ["collection", "organisationId"]
+                }
+            },
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.collections": {
+            "name": "collections",
+            "schema": "",
+            "columns": {
+                "versionId": {
+                    "name": "versionId",
+                    "type": "varchar",
+                    "primaryKey": true,
+                    "notNull": true
+                },
+                "entityId": {
+                    "name": "entityId",
+                    "type": "varchar",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "version": {
+                    "name": "version",
+                    "type": "integer",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "stateVersion": {
+                    "name": "stateVersion",
+                    "type": "integer",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "createdAt": {
+                    "name": "createdAt",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                },
+                "editedAt": {
+                    "name": "editedAt",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                },
+                "title": {
+                    "name": "title",
+                    "type": "varchar",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "description": {
+                    "name": "description",
+                    "type": "varchar",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "visibility": {
+                    "name": "visibility",
+                    "type": "collection_visibility_enum",
+                    "typeSchema": "public",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "'private'"
+                },
+                "defaultForNewExercises": {
+                    "name": "defaultForNewExercises",
+                    "type": "boolean",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": false
+                },
+                "draftState": {
+                    "name": "draftState",
+                    "type": "boolean",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "archived": {
+                    "name": "archived",
+                    "type": "boolean",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": false
+                }
+            },
+            "indexes": {},
+            "foreignKeys": {},
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {
+                "collections_versionId_unique": {
+                    "name": "collections_versionId_unique",
+                    "nullsNotDistinct": false,
+                    "columns": ["versionId"]
+                },
+                "unique_collection_version": {
+                    "name": "unique_collection_version",
+                    "nullsNotDistinct": false,
+                    "columns": ["entityId", "version"]
+                }
+            },
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.element_to_collection_mapping": {
+            "name": "element_to_collection_mapping",
+            "schema": "",
+            "columns": {
+                "collectionEntityId": {
+                    "name": "collectionEntityId",
+                    "type": "varchar",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "collectionVersionId": {
+                    "name": "collectionVersionId",
+                    "type": "varchar",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "elementEntityId": {
+                    "name": "elementEntityId",
+                    "type": "varchar",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "elementVersionId": {
+                    "name": "elementVersionId",
+                    "type": "uuid",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "isBaseReference": {
+                    "name": "isBaseReference",
+                    "type": "boolean",
+                    "primaryKey": false,
+                    "notNull": false,
+                    "default": false
+                }
+            },
+            "indexes": {},
+            "foreignKeys": {
+                "element_to_collection_mapping_collectionVersionId_collections_versionId_fk": {
+                    "name": "element_to_collection_mapping_collectionVersionId_collections_versionId_fk",
+                    "tableFrom": "element_to_collection_mapping",
+                    "tableTo": "collections",
+                    "columnsFrom": ["collectionVersionId"],
+                    "columnsTo": ["versionId"],
+                    "onDelete": "cascade",
+                    "onUpdate": "no action"
+                },
+                "element_to_collection_mapping_elementVersionId_elements_versionId_fk": {
+                    "name": "element_to_collection_mapping_elementVersionId_elements_versionId_fk",
+                    "tableFrom": "element_to_collection_mapping",
+                    "tableTo": "elements",
+                    "columnsFrom": ["elementVersionId"],
+                    "columnsTo": ["versionId"],
+                    "onDelete": "cascade",
+                    "onUpdate": "no action"
+                }
+            },
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {
+                "unique_element_collection_mapping": {
+                    "name": "unique_element_collection_mapping",
+                    "nullsNotDistinct": false,
+                    "columns": ["collectionVersionId", "elementVersionId"]
+                },
+                "unique_element_collection_mapping_2": {
+                    "name": "unique_element_collection_mapping_2",
+                    "nullsNotDistinct": false,
+                    "columns": ["collectionVersionId", "elementEntityId"]
+                }
+            },
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.elements": {
+            "name": "elements",
+            "schema": "",
+            "columns": {
+                "versionId": {
+                    "name": "versionId",
+                    "type": "uuid",
+                    "primaryKey": true,
+                    "notNull": true
+                },
+                "entityId": {
+                    "name": "entityId",
+                    "type": "varchar",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "version": {
+                    "name": "version",
+                    "type": "integer",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "stateVersion": {
+                    "name": "stateVersion",
+                    "type": "integer",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "createdAt": {
+                    "name": "createdAt",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                },
+                "editedAt": {
+                    "name": "editedAt",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                },
+                "title": {
+                    "name": "title",
+                    "type": "varchar",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "description": {
+                    "name": "description",
+                    "type": "varchar",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "content": {
+                    "name": "content",
+                    "type": "json",
+                    "primaryKey": false,
+                    "notNull": true
+                }
+            },
+            "indexes": {},
+            "foreignKeys": {},
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {
+                "elements_versionId_unique": {
+                    "name": "elements_versionId_unique",
+                    "nullsNotDistinct": false,
+                    "columns": ["versionId"]
+                },
+                "unique_template_version": {
+                    "name": "unique_template_version",
+                    "nullsNotDistinct": false,
+                    "columns": ["entityId", "version"]
+                },
+                "unique_template_id": {
+                    "name": "unique_template_id",
+                    "nullsNotDistinct": false,
+                    "columns": ["entityId", "versionId"]
+                }
+            },
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.exercise_entity": {
+            "name": "exercise_entity",
+            "schema": "",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "uuid",
+                    "primaryKey": true,
+                    "notNull": true
+                },
+                "tickCounter": {
+                    "name": "tickCounter",
+                    "type": "integer",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": 0
+                },
+                "initialStateString": {
+                    "name": "initialStateString",
+                    "type": "json",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "participantKey": {
+                    "name": "participantKey",
+                    "type": "char(6)",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "trainerKey": {
+                    "name": "trainerKey",
+                    "type": "char(8)",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "currentStateString": {
+                    "name": "currentStateString",
+                    "type": "json",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "stateVersion": {
+                    "name": "stateVersion",
+                    "type": "integer",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "organisationId": {
+                    "name": "organisationId",
+                    "type": "uuid",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "createdAt": {
+                    "name": "createdAt",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                },
+                "lastUsedAt": {
+                    "name": "lastUsedAt",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                },
+                "templateId": {
+                    "name": "templateId",
+                    "type": "uuid",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "baseTemplateId": {
+                    "name": "baseTemplateId",
+                    "type": "uuid",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "parallelExerciseId": {
+                    "name": "parallelExerciseId",
+                    "type": "uuid",
+                    "primaryKey": false,
+                    "notNull": false
+                }
+            },
+            "indexes": {},
+            "foreignKeys": {
+                "exercise_entity_organisationId_organisation_id_fk": {
+                    "name": "exercise_entity_organisationId_organisation_id_fk",
+                    "tableFrom": "exercise_entity",
+                    "tableTo": "organisation",
+                    "columnsFrom": ["organisationId"],
+                    "columnsTo": ["id"],
+                    "onDelete": "cascade",
+                    "onUpdate": "no action"
+                },
+                "exercise_entity_templateId_exercise_template_id_fk": {
+                    "name": "exercise_entity_templateId_exercise_template_id_fk",
+                    "tableFrom": "exercise_entity",
+                    "tableTo": "exercise_template",
+                    "columnsFrom": ["templateId"],
+                    "columnsTo": ["id"],
+                    "onDelete": "cascade",
+                    "onUpdate": "no action"
+                },
+                "exercise_entity_baseTemplateId_exercise_template_id_fk": {
+                    "name": "exercise_entity_baseTemplateId_exercise_template_id_fk",
+                    "tableFrom": "exercise_entity",
+                    "tableTo": "exercise_template",
+                    "columnsFrom": ["baseTemplateId"],
+                    "columnsTo": ["id"],
+                    "onDelete": "set null",
+                    "onUpdate": "no action"
+                },
+                "exercise_entity_parallelExerciseId_parallel_exercise_id_fk": {
+                    "name": "exercise_entity_parallelExerciseId_parallel_exercise_id_fk",
+                    "tableFrom": "exercise_entity",
+                    "tableTo": "parallel_exercise",
+                    "columnsFrom": ["parallelExerciseId"],
+                    "columnsTo": ["id"],
+                    "onDelete": "cascade",
+                    "onUpdate": "no action"
+                }
+            },
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {
+                "exercise_entity_participantKey_unique": {
+                    "name": "exercise_entity_participantKey_unique",
+                    "nullsNotDistinct": false,
+                    "columns": ["participantKey"]
+                },
+                "exercise_entity_trainerKey_unique": {
+                    "name": "exercise_entity_trainerKey_unique",
+                    "nullsNotDistinct": false,
+                    "columns": ["trainerKey"]
+                }
+            },
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.exercise_template": {
+            "name": "exercise_template",
+            "schema": "",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "uuid",
+                    "primaryKey": true,
+                    "notNull": true
+                },
+                "organisationId": {
+                    "name": "organisationId",
+                    "type": "uuid",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "createdAt": {
+                    "name": "createdAt",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                },
+                "lastUpdatedAt": {
+                    "name": "lastUpdatedAt",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                },
+                "lastExerciseCreatedAt": {
+                    "name": "lastExerciseCreatedAt",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "name": {
+                    "name": "name",
+                    "type": "varchar",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "description": {
+                    "name": "description",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "''"
+                }
+            },
+            "indexes": {},
+            "foreignKeys": {
+                "exercise_template_organisationId_organisation_id_fk": {
+                    "name": "exercise_template_organisationId_organisation_id_fk",
+                    "tableFrom": "exercise_template",
+                    "tableTo": "organisation",
+                    "columnsFrom": ["organisationId"],
+                    "columnsTo": ["id"],
+                    "onDelete": "cascade",
+                    "onUpdate": "no action"
+                }
+            },
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.organisation_invite_link": {
+            "name": "organisation_invite_link",
+            "schema": "",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "uuid",
+                    "primaryKey": true,
+                    "notNull": true
+                },
+                "token": {
+                    "name": "token",
+                    "type": "varchar",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "organisationId": {
+                    "name": "organisationId",
+                    "type": "uuid",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "expirationDate": {
+                    "name": "expirationDate",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": true
+                }
+            },
+            "indexes": {},
+            "foreignKeys": {
+                "organisation_invite_link_organisationId_organisation_id_fk": {
+                    "name": "organisation_invite_link_organisationId_organisation_id_fk",
+                    "tableFrom": "organisation_invite_link",
+                    "tableTo": "organisation",
+                    "columnsFrom": ["organisationId"],
+                    "columnsTo": ["id"],
+                    "onDelete": "cascade",
+                    "onUpdate": "no action"
+                }
+            },
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.organisation_membership": {
+            "name": "organisation_membership",
+            "schema": "",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "uuid",
+                    "primaryKey": true,
+                    "notNull": true
+                },
+                "userId": {
+                    "name": "userId",
+                    "type": "varchar",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "organisationId": {
+                    "name": "organisationId",
+                    "type": "uuid",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "role": {
+                    "name": "role",
+                    "type": "organisation_membership_role",
+                    "typeSchema": "public",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "joinedAt": {
+                    "name": "joinedAt",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                }
+            },
+            "indexes": {
+                "organisation_membership_organisationId_role_index": {
+                    "name": "organisation_membership_organisationId_role_index",
+                    "columns": [
+                        {
+                            "expression": "organisationId",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        },
+                        {
+                            "expression": "role",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                }
+            },
+            "foreignKeys": {
+                "organisation_membership_userId_users_id_fk": {
+                    "name": "organisation_membership_userId_users_id_fk",
+                    "tableFrom": "organisation_membership",
+                    "tableTo": "users",
+                    "columnsFrom": ["userId"],
+                    "columnsTo": ["id"],
+                    "onDelete": "cascade",
+                    "onUpdate": "no action"
+                },
+                "organisation_membership_organisationId_organisation_id_fk": {
+                    "name": "organisation_membership_organisationId_organisation_id_fk",
+                    "tableFrom": "organisation_membership",
+                    "tableTo": "organisation",
+                    "columnsFrom": ["organisationId"],
+                    "columnsTo": ["id"],
+                    "onDelete": "cascade",
+                    "onUpdate": "no action"
+                }
+            },
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {
+                "organisation_membership_userId_organisationId_unique": {
+                    "name": "organisation_membership_userId_organisationId_unique",
+                    "nullsNotDistinct": false,
+                    "columns": ["userId", "organisationId"]
+                }
+            },
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.organisation": {
+            "name": "organisation",
+            "schema": "",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "uuid",
+                    "primaryKey": true,
+                    "notNull": true
+                },
+                "name": {
+                    "name": "name",
+                    "type": "varchar",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "description": {
+                    "name": "description",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "''"
+                },
+                "createdAt": {
+                    "name": "createdAt",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                },
+                "personalOrganisationOf": {
+                    "name": "personalOrganisationOf",
+                    "type": "varchar",
+                    "primaryKey": false,
+                    "notNull": false
+                }
+            },
+            "indexes": {},
+            "foreignKeys": {
+                "organisation_personalOrganisationOf_users_id_fk": {
+                    "name": "organisation_personalOrganisationOf_users_id_fk",
+                    "tableFrom": "organisation",
+                    "tableTo": "users",
+                    "columnsFrom": ["personalOrganisationOf"],
+                    "columnsTo": ["id"],
+                    "onDelete": "cascade",
+                    "onUpdate": "no action"
+                }
+            },
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {
+                "organisation_personalOrganisationOf_unique": {
+                    "name": "organisation_personalOrganisationOf_unique",
+                    "nullsNotDistinct": false,
+                    "columns": ["personalOrganisationOf"]
+                }
+            },
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.parallel_exercise": {
+            "name": "parallel_exercise",
+            "schema": "",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "uuid",
+                    "primaryKey": true,
+                    "notNull": true
+                },
+                "organisationId": {
+                    "name": "organisationId",
+                    "type": "uuid",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "createdAt": {
+                    "name": "createdAt",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                },
+                "name": {
+                    "name": "name",
+                    "type": "varchar",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "templateId": {
+                    "name": "templateId",
+                    "type": "uuid",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "templateStateString": {
+                    "name": "templateStateString",
+                    "type": "json",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "participantKey": {
+                    "name": "participantKey",
+                    "type": "char(7)",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "joinViewportId": {
+                    "name": "joinViewportId",
+                    "type": "uuid",
+                    "primaryKey": false,
+                    "notNull": true
+                }
+            },
+            "indexes": {},
+            "foreignKeys": {
+                "parallel_exercise_organisationId_organisation_id_fk": {
+                    "name": "parallel_exercise_organisationId_organisation_id_fk",
+                    "tableFrom": "parallel_exercise",
+                    "tableTo": "organisation",
+                    "columnsFrom": ["organisationId"],
+                    "columnsTo": ["id"],
+                    "onDelete": "cascade",
+                    "onUpdate": "no action"
+                },
+                "parallel_exercise_templateId_exercise_template_id_fk": {
+                    "name": "parallel_exercise_templateId_exercise_template_id_fk",
+                    "tableFrom": "parallel_exercise",
+                    "tableTo": "exercise_template",
+                    "columnsFrom": ["templateId"],
+                    "columnsTo": ["id"],
+                    "onDelete": "cascade",
+                    "onUpdate": "no action"
+                }
+            },
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {
+                "parallel_exercise_participantKey_unique": {
+                    "name": "parallel_exercise_participantKey_unique",
+                    "nullsNotDistinct": false,
+                    "columns": ["participantKey"]
+                }
+            },
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.sessions": {
+            "name": "sessions",
+            "schema": "",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "varchar",
+                    "primaryKey": true,
+                    "notNull": true
+                },
+                "userId": {
+                    "name": "userId",
+                    "type": "varchar",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "createdAt": {
+                    "name": "createdAt",
+                    "type": "timestamp (3)",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                },
+                "expiresAt": {
+                    "name": "expiresAt",
+                    "type": "timestamp (3)",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "accessToken": {
+                    "name": "accessToken",
+                    "type": "varchar",
+                    "primaryKey": false,
+                    "notNull": true
+                }
+            },
+            "indexes": {},
+            "foreignKeys": {
+                "sessions_userId_users_id_fk": {
+                    "name": "sessions_userId_users_id_fk",
+                    "tableFrom": "sessions",
+                    "tableTo": "users",
+                    "columnsFrom": ["userId"],
+                    "columnsTo": ["id"],
+                    "onDelete": "cascade",
+                    "onUpdate": "cascade"
+                }
+            },
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.users": {
+            "name": "users",
+            "schema": "",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "varchar",
+                    "primaryKey": true,
+                    "notNull": true
+                },
+                "username": {
+                    "name": "username",
+                    "type": "varchar",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "displayName": {
+                    "name": "displayName",
+                    "type": "varchar",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "updatedAt": {
+                    "name": "updatedAt",
+                    "type": "timestamp (3)",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                }
+            },
+            "indexes": {},
+            "foreignKeys": {},
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        }
+    },
+    "enums": {
+        "public.collection_visibility_enum": {
+            "name": "collection_visibility_enum",
+            "schema": "public",
+            "values": ["public", "private", "embedded"]
+        }
+    },
+    "schemas": {},
+    "sequences": {},
+    "roles": {},
+    "policies": {},
+    "views": {},
+    "_meta": {
+        "columns": {},
+        "schemas": {},
+        "tables": {}
+    }
+}

--- a/backend/drizzle/meta/_journal.json
+++ b/backend/drizzle/meta/_journal.json
@@ -92,6 +92,13 @@
             "when": 1784832456580,
             "tag": "0012_marketplace",
             "breakpoints": true
+        },
+        {
+            "idx": 13,
+            "version": "7",
+            "when": 1785763914284,
+            "tag": "0013_marketplace_defaultcollection",
+            "breakpoints": true
         }
     ]
 }

--- a/backend/src/database/default-data/collection-default-data.ts
+++ b/backend/src/database/default-data/collection-default-data.ts
@@ -35,6 +35,7 @@ function newElementEntityId(uuid: string) {
 // IF YOU WANT TO CHANGE THESE ELEMENTS,
 // PLEASE CREATE A NEW SET OF DEFAULT ELEMENTS (e.g.  FüSim Digital {YEAR} Übungselemente)
 const fuesimDigital20250629DefaultCollectionData: DefaultCollection = {
+    defaultForNewExercises: true,
     entityId: collectionEntityIdSchema.parse(
         'collection_entity_76dcdff5-9dd5-4430-b7a7-f680479977ae'
     ),

--- a/backend/src/database/repositories/collection-repository.ts
+++ b/backend/src/database/repositories/collection-repository.ts
@@ -64,6 +64,21 @@ export class CollectionRepository extends BaseRepository {
             // This is slow with seperate queries, but we dont have that much default data and it is only run once,
             // so it should be fine for now :3
 
+            // check the default data for correctness
+            const defaultForNewExercisesCollectionAmount =
+                defaultCollectionData.reduce((acc, collection) => {
+                    if (collection.defaultForNewExercises) {
+                        return acc + 1;
+                    }
+                    return acc;
+                }, 0);
+
+            if (defaultForNewExercisesCollectionAmount !== 1) {
+                throw new Error(
+                    `There should be exactly one defaultForNewExercises collection, but there are ${defaultForNewExercisesCollectionAmount}`
+                );
+            }
+
             // CLEANUP existing default data to avoid conflicts
             const existingCollections = await tx.databaseConnection
                 .select()
@@ -108,6 +123,8 @@ export class CollectionRepository extends BaseRepository {
                     > = {
                         entityId: collection.entityId,
                         versionId: collection.versionId,
+                        defaultForNewExercises:
+                            collection.defaultForNewExercises,
                         title: collection.title,
                         description: collection.description,
                         archived: collection.archived,

--- a/backend/src/database/schema.ts
+++ b/backend/src/database/schema.ts
@@ -323,6 +323,7 @@ export const collectionTable = pgTable(
         title: varchar().notNull(),
         description: varchar().notNull(),
         visibility: collectionVisibilityEnum().notNull().default('private'),
+        defaultForNewExercises: boolean().notNull().default(false),
         draftState: boolean().notNull(),
         archived: boolean().notNull().default(false),
         // fyi: we cant use computed/generated columns for

--- a/frontend/src/app/pages/marketplace/shared/modals/marketplace-select-collection-modal/marketplace-select-collection-modal.component.ts
+++ b/frontend/src/app/pages/marketplace/shared/modals/marketplace-select-collection-modal/marketplace-select-collection-modal.component.ts
@@ -66,13 +66,19 @@ export class MarketplaceSelectCollectionModalComponent {
 
             const userAvailableCollections =
                 this.userAvailableCollections.value();
-            if (this.skipOnNoChoice && userAvailableCollections.length === 1) {
-                const firstCollection = userAvailableCollections[0];
-                if (firstCollection === undefined) {
-                    console.warn('only collection is undefined');
+            const userCreatedCollections = userAvailableCollections.filter(
+                (collection) => collection.visibility !== 'embedded'
+            );
+
+            if (this.skipOnNoChoice && userCreatedCollections.length === 0) {
+                const defaultCollection = userAvailableCollections.find(
+                    (collection) => collection.defaultForNewExercises
+                );
+                if (defaultCollection === undefined) {
+                    console.warn('default collection is undefined');
                     return;
                 }
-                this.close(firstCollection);
+                this.close(defaultCollection);
             }
         });
     }

--- a/shared/src/marketplace/models/collection.ts
+++ b/shared/src/marketplace/models/collection.ts
@@ -20,6 +20,7 @@ export const collectionVersionSchema = z.object({
     visibility: collectionVisibilitySchema,
     draftState: z.boolean(),
     archived: z.boolean(),
+    defaultForNewExercises: z.boolean(),
 });
 
 export type CollectionVersion = z.infer<typeof collectionVersionSchema>;


### PR DESCRIPTION
### Summary

- Allows for one specified default collection when new users create an exercise instead of just using "the one" embedded collection

Fix especially for #1655 

Important: Since this only add to a release candidate, theres no changelog entry for this.

### PR Checklist

Please make sure to fulfil the following conditions before marking this PR ready for review:

- [X] If this PR adds or changes features or fixes bugs, this has been added to the changelog.
- [ ] If this PR adds or changes features, the related documentation has been updated.
- [X] If this PR adds new actions or other ways to alter the state, [test scenarios](https://github.com/hpi-sam/fuesim-digital-public-test-scenarios) have been added.
- [X] By signing off my commits (`git commit -s`), I certify that I have read and adhere to the terms of the [Developer Certificate of Origin 1.1](https://developercertificate.org/) and license the code in this Pull Request under this projects license ([LICENSE-README.md](https://github.com/hpi-sam/fuesim-digital/blob/dev/LICENSE-README.md)).
- [X] If I have used third party code that requires attribution, I have mentioned it in the code and updated [inspired-by-or-copied-from-list.html](https://github.com/hpi-sam/fuesim-digital/blob/dev/inspired-by-or-copied-from-list.html).
