### PR TITLE
Fix spacing around link on landing page

### DIFF
--- a/frontend/src/app/pages/landing-page/landing-page/landing-page.component.html
+++ b/frontend/src/app/pages/landing-page/landing-page/landing-page.component.html
@@ -171,7 +171,7 @@
         <p>
             Der Quelltext dieser Webseite und die dahinterstehenden Technologien
             stehen als Open-Source-Software auf
-            <a href="https://github.com/hpi-sam/fuesim-digital"> GitHub </a>
+            <a href="https://github.com/hpi-sam/fuesim-digital">GitHub</a>
             zur Verfügung. Weitere Informationen über dieses und weitere
             Projekte finden Sie auf der
             <a href="https://manv-simulation.de">Projektwebseite</a>.


### PR DESCRIPTION
### Summary

Fix the spacing around the GitHub link on the landing page, to avoid rendering like this:
<img width="126" height="47" alt="image" src="https://github.com/user-attachments/assets/4b7d0ffd-4829-4d47-912a-09e0da305678" />


Due to the minuscule nature of this fix, I will not mention it in the changelog.

### PR Checklist

Please make sure to fulfil the following conditions before marking this PR ready for review:

- [ ] If this PR adds or changes features or fixes bugs, this has been added to the changelog.
- [ ] If this PR adds or changes features, the related documentation has been updated.
- [x] If this PR adds new actions or other ways to alter the state, [test scenarios](https://github.com/hpi-sam/fuesim-digital-public-test-scenarios) have been added.
- [x] By signing off my commits (`git commit -s`), I certify that I have read and adhere to the terms of the [Developer Certificate of Origin 1.1](https://developercertificate.org/) and license the code in this Pull Request under this projects license ([LICENSE-README.md](https://github.com/hpi-sam/fuesim-digital/blob/dev/LICENSE-README.md)).
- [x] If I have used third party code that requires attribution, I have mentioned it in the code and updated [inspired-by-or-copied-from-list.html](https://github.com/hpi-sam/fuesim-digital/blob/dev/inspired-by-or-copied-from-list.html).
