### PR TITLE
Fix migration of outdated elements

### DIFF
--- a/backend/src/database/services/collection-service.ts
+++ b/backend/src/database/services/collection-service.ts
@@ -14,10 +14,8 @@ import type {
     VersionedElementPartial,
     OrganisationId,
     CollectionOrganisationRelationshipType,
-    ExerciseState,
     CollectionMembershipRole,
     CollectionVisibility,
-    AlarmGroup,
 } from 'fuesim-digital-shared';
 import {
     applyMigrations,
@@ -34,7 +32,7 @@ import {
     extendedCollectionVersionReducer,
 } from 'fuesim-digital-shared';
 import { Subject } from 'rxjs';
-import type { WritableDraft } from 'immer';
+import { castDraft, type WritableDraft } from 'immer';
 import type { CollectionRepository } from '../repositories/collection-repository.js';
 import type { SessionInformation } from '../../auth/auth-service.js';
 import type { ExerciseService } from './exercise-service.js';
@@ -1899,17 +1897,14 @@ export class CollectionService {
                     );
                 }
 
-                let state = cloneDeepMutable(
-                    newExerciseState(
-                        '123456' as ParticipantKey
-                    ) as WritableDraft<ExerciseState>
+                let state = castDraft(
+                    newExerciseState('123456' as ParticipantKey)
                 );
 
                 state = Object.assign(state, {
                     templates: allElementsOfStateVersion.reduce<{
                         [T in ElementVersionId]: WritableDraft<TemplateVersionContent>;
                     }>((acc, element) => {
-                        if (element.content.type === 'alarmGroup') return acc;
                         acc[element.versionId] = {
                             ...cloneDeepMutable(element.content),
                             entity: {
@@ -1920,21 +1915,7 @@ export class CollectionService {
                         };
                         return acc;
                     }, {}),
-                    alarmGroups: allElementsOfStateVersion.reduce<{
-                        [T in ElementVersionId]: WritableDraft<AlarmGroup>;
-                    }>((acc, element) => {
-                        if (element.content.type !== 'alarmGroup') return acc;
-                        acc[element.versionId] = {
-                            ...cloneDeepMutable(element.content),
-                            entity: {
-                                entityId: element.entityId,
-                                versionId: element.versionId,
-                                type: 'direct',
-                            },
-                        };
-                        return acc;
-                    }, {}),
-                } satisfies { [T in keyof ExerciseState]?: any });
+                });
 
                 const migratedState = applyMigrations(currentElementVersion, {
                     currentState: state,
@@ -1943,14 +1924,9 @@ export class CollectionService {
 
                 const affectedElementCount = await tx.UNSAFE_overwriteElements(
                     currentStateVersion,
-                    [
-                        ...Object.values(
-                            migratedState.currentState.templates
-                        ).filter(isMarketplaceElementContent),
-                        ...Object.values(
-                            migratedState.currentState.alarmGroups
-                        ).filter(isMarketplaceElementContent),
-                    ]
+                    Object.values(migratedState.currentState.templates).filter(
+                        isMarketplaceElementContent
+                    )
                 );
 
                 combinedAffectedElementCount += affectedElementCount;

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -167,13 +167,13 @@ async function main() {
                 await collectionService.upgradeAllElementStateVersionsToLatest();
             const endTime = performance.now();
             console.log(
-                `✅ Successfully upgraded ${versionCount} Element StateVersions in ${(
+                `✅ Successfully migrated ${versionCount} collection element(s) to current state version in ${(
                     endTime - startTime
                 ).toFixed(3)} ms.`
             );
         } catch (e: unknown) {
             console.error(
-                '❌ An error occurred while upgrading Element StateVersions.'
+                '❌ An error occurred while migrating collection elements to current state version.'
             );
             throw e;
         }


### PR DESCRIPTION
### Summary

I think that the extra handling of the alarm groups is not necessary. But definitely it causes problems because of an id mismatch (idMapSchema validation for `alarmGroups` fails).

### PR Checklist

Please make sure to fulfil the following conditions before marking this PR ready for review:

- [x] If this PR adds or changes features or fixes bugs, this has been added to the changelog.
- [x] If this PR adds or changes features, the related documentation has been updated.
- [x] If this PR adds new actions or other ways to alter the state, [test scenarios](https://github.com/hpi-sam/fuesim-digital-public-test-scenarios) have been added.
- [x] By signing off my commits (`git commit -s`), I certify that I have read and adhere to the terms of the [Developer Certificate of Origin 1.1](https://developercertificate.org/) and license the code in this Pull Request under this projects license ([LICENSE-README.md](https://github.com/hpi-sam/fuesim-digital/blob/dev/LICENSE-README.md)).
- [x] If I have used third party code that requires attribution, I have mentioned it in the code and updated [inspired-by-or-copied-from-list.html](https://github.com/hpi-sam/fuesim-digital/blob/dev/inspired-by-or-copied-from-list.html).
