### PR TITLE
Fix behavior of collection element view button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project does **not** adhere to [Semantic Versioning](https://semver.org
 ### Fixed
 
 - On longer pages, messages were shown outside the viewport.
+- The view button of elements cards shown in the marketplace now actually opens the element's details view instead of the duplicate modal.
 
 ## [1.0.0-rc.2] - 2026-08-13
 

--- a/frontend/src/app/pages/marketplace/shared/cards/generic-element-card/generic-element-card.component.html
+++ b/frontend/src/app/pages/marketplace/shared/cards/generic-element-card/generic-element-card.component.html
@@ -113,9 +113,7 @@
                     class="btn btn-outline-secondary btn-sm flex-grow-1 px-2"
                     ngbTooltip="Ansehen"
                     placement="top"
-                    (click)="
-                        $event.stopPropagation(); output.duplicateExternal()
-                    "
+                    (click)="$event.stopPropagation(); output.click()"
                 >
                     <i class="bi bi-eye"></i>
                 </button>


### PR DESCRIPTION
### Summary

The view button of the `generic-element-card` also opened the `duplicateExternal` modal

### PR Checklist

Please make sure to fulfil the following conditions before marking this PR ready for review:

- [x] If this PR adds or changes features or fixes bugs, this has been added to the changelog.
- [x] If this PR adds or changes features, the related documentation has been updated.
- [x] If this PR adds new actions or other ways to alter the state, [test scenarios](https://github.com/hpi-sam/fuesim-digital-public-test-scenarios) have been added.
- [x] By signing off my commits (`git commit -s`), I certify that I have read and adhere to the terms of the [Developer Certificate of Origin 1.1](https://developercertificate.org/) and license the code in this Pull Request under this projects license ([LICENSE-README.md](https://github.com/hpi-sam/fuesim-digital/blob/dev/LICENSE-README.md)).
- [x] If I have used third party code that requires attribution, I have mentioned it in the code and updated [inspired-by-or-copied-from-list.html](https://github.com/hpi-sam/fuesim-digital/blob/dev/inspired-by-or-copied-from-list.html).
