### PR TITLE
Show users as collections members

### DIFF
--- a/backend/src/database/repositories/collection-repository.ts
+++ b/backend/src/database/repositories/collection-repository.ts
@@ -42,6 +42,7 @@ import {
     collectionOrganisationMappingTable,
     organisationTable,
     exerciseTable,
+    userTable,
 } from '../schema.js';
 import { defaultCollectionData } from '../default-data/collection-default-data.js';
 import { DAG } from '../../utils/dag.js';
@@ -330,9 +331,10 @@ export class CollectionRepository extends BaseRepository {
             .select({
                 id: organisationTable.id,
                 name: organisationTable.name,
-                owner: collectionOrganisationMappingTable.owner,
+                isOwner: collectionOrganisationMappingTable.owner,
                 personalOrganisationOf:
                     organisationTable.personalOrganisationOf,
+                personalOrganisationOfName: userTable.displayName,
             })
             .from(collectionOrganisationMappingTable)
             .innerJoin(
@@ -341,6 +343,10 @@ export class CollectionRepository extends BaseRepository {
                     collectionOrganisationMappingTable.organisationId,
                     organisationTable.id
                 )
+            )
+            .leftJoin(
+                userTable,
+                eq(organisationTable.personalOrganisationOf, userTable.id)
             )
             .where(
                 eq(

--- a/frontend/src/app/pages/marketplace/collection-detail-view/collection-properties-tab/collection-member-item/collection-member-item.component.html
+++ b/frontend/src/app/pages/marketplace/collection-detail-view/collection-properties-tab/collection-member-item/collection-member-item.component.html
@@ -2,20 +2,25 @@
     @let isPersonalOrganisationMember =
         member().personalOrganisationOf === ownUserId();
     <span>
-        {{ member().name }}
-        @if (isPersonalOrganisationMember) {
-            <span class="badge text-bg-info text-white ms-1"
-                >Ihre Private Organisation</span
-            >
+        @if (member().personalOrganisationOf){
+            {{ member().personalOrganisationOfName }}
+            @if (isPersonalOrganisationMember) {
+                <span class="badge text-bg-primary text-white ms-1">
+                    <i class="bi bi-person me-1"></i>
+                    Das sind sie
+                </span>
+            }
+        }@else{
+            {{ member().name }}
         }
-        @if (member().owner) {
-            <span class="badge text-bg-primary ms-1">Besitzer</span>
+        @if (member().isOwner) {
+            <span class="badge text-bg-info ms-1">Besitzer</span>
         }
-        @if (!member().owner && !isPersonalOrganisationMember) {
+        @else {
             <span class="badge text-bg-secondary ms-1">Betrachter</span>
         }
     </span>
-    @if (!member().owner) {
+    @if (!member().isOwner) {
         <button
             class="btn btn-outline-info btn-sm ms-auto"
             (click)="setCollectionOwner(member().id, member().name)"

--- a/frontend/src/app/pages/marketplace/collection-detail-view/collection-properties-tab/collection-member-item/collection-member-item.component.html
+++ b/frontend/src/app/pages/marketplace/collection-detail-view/collection-properties-tab/collection-member-item/collection-member-item.component.html
@@ -2,21 +2,20 @@
     @let isPersonalOrganisationMember =
         member().personalOrganisationOf === ownUserId();
     <span>
-        @if (member().personalOrganisationOf){
+        @if (member().personalOrganisationOf) {
             {{ member().personalOrganisationOfName }}
             @if (isPersonalOrganisationMember) {
                 <span class="badge text-bg-primary text-white ms-1">
                     <i class="bi bi-person me-1"></i>
-                    Das sind sie
+                    Das sind Sie
                 </span>
             }
-        }@else{
+        } @else {
             {{ member().name }}
         }
         @if (member().isOwner) {
             <span class="badge text-bg-info ms-1">Besitzer</span>
-        }
-        @else {
+        } @else {
             <span class="badge text-bg-secondary ms-1">Betrachter</span>
         }
     </span>

--- a/frontend/src/app/pages/marketplace/collection-detail-view/collection-properties-tab/collection-member-item/collection-member-item.component.ts
+++ b/frontend/src/app/pages/marketplace/collection-detail-view/collection-properties-tab/collection-member-item/collection-member-item.component.ts
@@ -4,7 +4,6 @@ import {
     inject,
     input,
     output,
-    resource,
     ChangeDetectionStrategy,
 } from '@angular/core';
 import {

--- a/frontend/src/app/pages/marketplace/collection-detail-view/collection-properties-tab/collection-member-item/collection-member-item.component.ts
+++ b/frontend/src/app/pages/marketplace/collection-detail-view/collection-properties-tab/collection-member-item/collection-member-item.component.ts
@@ -60,7 +60,7 @@ export class CollectionMemberItemComponent {
         return (
             (orgData.value().userRole === 'editor' ||
                 orgData.value().userRole === 'admin') &&
-            !this.member().owner
+            !this.member().isOwner
         );
     });
 

--- a/frontend/src/app/pages/marketplace/collection-detail-view/collection-properties-tab/collection-member-item/collection-member-item.component.ts
+++ b/frontend/src/app/pages/marketplace/collection-detail-view/collection-properties-tab/collection-member-item/collection-member-item.component.ts
@@ -41,28 +41,9 @@ export class CollectionMemberItemComponent {
     public readonly collection = input.required<CollectionVersion>();
     public readonly showRemoveButton = input<boolean>(false);
 
-    public organisationData = resource({
-        params: () => ({
-            memberId: this.member().id,
-        }),
-        loader: async ({ params: { memberId } }) =>
-            this.apiService.getOrganisation(memberId),
-    });
-
     public readonly ownUserId = computed(
         () => this.authService.authData().user?.id
     );
-
-    public readonly canLeaveCollection = computed(() => {
-        const orgData = this.organisationData;
-        if (!orgData.hasValue()) return false;
-
-        return (
-            (orgData.value().userRole === 'editor' ||
-                orgData.value().userRole === 'admin') &&
-            !this.member().isOwner
-        );
-    });
 
     public async removeCollectionMember(
         organisationId: OrganisationId,

--- a/frontend/src/app/pages/marketplace/collection-detail-view/collection-properties-tab/collection-properties-tab.component.html
+++ b/frontend/src/app/pages/marketplace/collection-detail-view/collection-properties-tab/collection-properties-tab.component.html
@@ -45,7 +45,7 @@
             >
                 <i class="bi bi-people"></i>
                 <i class="bi bi-plus"></i>
-                Organisation hinzufügen
+                Organisation als Mitglied hinzufügen
             </button>
 
             <button

--- a/frontend/src/app/pages/marketplace/collection-detail-view/collection-properties-tab/collection-properties-tab.component.html
+++ b/frontend/src/app/pages/marketplace/collection-detail-view/collection-properties-tab/collection-properties-tab.component.html
@@ -54,7 +54,7 @@
                 (click)="invite()"
             >
                 <i class="bi bi-key me-1"></i>
-                Einladungscode erstellen
+                Mitglieder mit Einladungscode einladen
             </button>
 
             <button
@@ -63,7 +63,7 @@
                 (click)="revokeInviteCode()"
             >
                 <i class="bi bi-shield-x me-1"></i>
-                Alle Einladungscodes zurückrufen
+                Bestehende Einladungscodes zurückrufen
             </button>
         </div>
 

--- a/frontend/src/app/pages/marketplace/collection-detail-view/collection-properties-tab/collection-properties-tab.component.ts
+++ b/frontend/src/app/pages/marketplace/collection-detail-view/collection-properties-tab/collection-properties-tab.component.ts
@@ -143,8 +143,8 @@ export class CollectionDetailsTabComponent {
         const confirmationResult = await this.confirmationModalService.confirm({
             title: 'Alle Einladungscodes widerrufen',
             description:
-                'Möchten Sie wirklich alle Einladungscode widerrufen? Dadurch können bereits verteilte Einladungscodes nicht mehr genutzt werden. Diese Aktion kann nicht rückgängig gemacht werden.',
-            confirmationButtonText: 'Alle Einladungscodes widerrufen',
+                'Möchten Sie wirklich alle bestehenden Einladungscode widerrufen? Dadurch können bereits verteilte Einladungscodes nicht mehr genutzt werden. Diese Aktion kann nicht rückgängig gemacht werden.',
+            confirmationButtonText: 'Einladungscodes widerrufen',
         });
         if (!confirmationResult) return;
         await this.collectionService.revokeCollectionInviteCode(

--- a/frontend/src/app/pages/marketplace/collection-detail-view/collection-properties-tab/collection-properties-tab.component.ts
+++ b/frontend/src/app/pages/marketplace/collection-detail-view/collection-properties-tab/collection-properties-tab.component.ts
@@ -66,7 +66,7 @@ export class CollectionDetailsTabComponent {
                     })
             )
                 .sort((a, b) => b.name.localeCompare(a.name))
-                .sort((a, b) => Number(b.owner) - Number(a.owner)),
+                .sort((a, b) => Number(b.isOwner) - Number(a.isOwner)),
     });
 
     public readonly userIsEditor = resource({
@@ -81,7 +81,7 @@ export class CollectionDetailsTabComponent {
             const userId = this.authService.authData().user?.id;
             if (!userId) return false;
 
-            const ownerOrganisation = members.find((member) => member.owner);
+            const ownerOrganisation = members.find((member) => member.isOwner);
             if (!ownerOrganisation) return false;
 
             try {
@@ -112,7 +112,7 @@ export class CollectionDetailsTabComponent {
             this.ngbModalService,
             {
                 descriptionText:
-                    'Bitte wählen Sie eine Organisation aus, die Sie zu dieser Sammlung hinzufügen möchten. Die Organisation wird als Betrachter hinzugefügt.',
+                    'Bitte wählen Sie eine der Organisationen, bei der sie Bearbeiter oder Administrator sind, aus, um sie zu dieser Sammlung als Mitglied hinzuzufügen. Die Organisation wird als Betrachter hinzugefügt.',
             }
         );
 
@@ -128,7 +128,8 @@ export class CollectionDetailsTabComponent {
             title: 'Mitglieder einladen',
             description: `Sie können an dieser Stelle einen Zugriffscode erstellen, den sie an andere
                 Personen weitergeben können und welcher sieben Tage lang gültig ist.
-                Diese können dann über die Übungselemente-Startseite mit einer Organisation dieser Sammlung als Betrachter beitreten.
+                Diese können dann über die Übungselemente-Startseite mit ihrem Benutzeraccount oder mit einer Organisationen bei der sie Mitglied sind dieser Sammlung beitreten.
+                Der neu begetretene Benutzeraccount bzw. die neu beigetretene Organisationen wird initial als Betrachter geführt.
                 `,
             type: 'Zugriffscode',
             createInviteFn: async () =>

--- a/frontend/src/app/pages/marketplace/collection-detail-view/collection-properties-tab/collection-properties-tab.component.ts
+++ b/frontend/src/app/pages/marketplace/collection-detail-view/collection-properties-tab/collection-properties-tab.component.ts
@@ -112,7 +112,7 @@ export class CollectionDetailsTabComponent {
             this.ngbModalService,
             {
                 descriptionText:
-                    'Bitte wählen Sie eine der Organisationen, bei der sie Bearbeiter oder Administrator sind, aus, um sie zu dieser Sammlung als Mitglied hinzuzufügen. Die Organisation wird als Betrachter hinzugefügt.',
+                    'Bitte wählen Sie eine der Organisationen aus, bei der sie Bearbeiter oder Administrator sind, um sie zu dieser Sammlung als Mitglied hinzuzufügen. Die Organisation wird als Betrachter hinzugefügt.',
             }
         );
 

--- a/frontend/src/app/pages/marketplace/collection-detail-view/collection-properties-tab/collection-properties-tab.component.ts
+++ b/frontend/src/app/pages/marketplace/collection-detail-view/collection-properties-tab/collection-properties-tab.component.ts
@@ -129,7 +129,7 @@ export class CollectionDetailsTabComponent {
             description: `Sie können an dieser Stelle einen Zugriffscode erstellen, den sie an andere
                 Personen weitergeben können und welcher sieben Tage lang gültig ist.
                 Diese können dann über die Übungselemente-Startseite mit ihrem Benutzerkonto oder mit einer Organisation, in der sie Mitglied sind, dieser Sammlung beitreten.
-                Der neu begetretene Benutzeraccount bzw. die neu beigetretene Organisationen wird initial als Betrachter geführt.
+                Das neu begetretene Benutzerkonto bzw. die neu beigetretene Organisation wird initial als Betrachter geführt.
                 `,
             type: 'Zugriffscode',
             createInviteFn: async () =>

--- a/frontend/src/app/pages/marketplace/collection-detail-view/collection-properties-tab/collection-properties-tab.component.ts
+++ b/frontend/src/app/pages/marketplace/collection-detail-view/collection-properties-tab/collection-properties-tab.component.ts
@@ -128,7 +128,7 @@ export class CollectionDetailsTabComponent {
             title: 'Mitglieder einladen',
             description: `Sie können an dieser Stelle einen Zugriffscode erstellen, den sie an andere
                 Personen weitergeben können und welcher sieben Tage lang gültig ist.
-                Diese können dann über die Übungselemente-Startseite mit ihrem Benutzeraccount oder mit einer Organisationen bei der sie Mitglied sind dieser Sammlung beitreten.
+                Diese können dann über die Übungselemente-Startseite mit ihrem Benutzerkonto oder mit einer Organisation, in der sie Mitglied sind, dieser Sammlung beitreten.
                 Der neu begetretene Benutzeraccount bzw. die neu beigetretene Organisationen wird initial als Betrachter geführt.
                 `,
             type: 'Zugriffscode',

--- a/frontend/src/app/pages/marketplace/shared/modals/select-organisation-modal/select-organisation-modal.component.html
+++ b/frontend/src/app/pages/marketplace/shared/modals/select-organisation-modal/select-organisation-modal.component.html
@@ -23,6 +23,10 @@
             [field]="selectOrgaForm.organisationId()"
         />
     </div>
+    <p class="text-muted">
+        Hinweis: Bei "Private Inhalte" handelt es sich um Ihre persönliche
+        Organisation. Sie wählen damit Ihren Benutzeraccount aus.
+    </p>
 
     <button
         class="btn btn-primary"

--- a/frontend/src/app/pages/marketplace/shared/modals/select-organisation-modal/select-organisation-modal.component.html
+++ b/frontend/src/app/pages/marketplace/shared/modals/select-organisation-modal/select-organisation-modal.component.html
@@ -25,7 +25,7 @@
     </div>
     <p class="text-muted">
         Hinweis: Bei "Private Inhalte" handelt es sich um Ihre persönliche
-        Organisation. Sie wählen damit Ihren Benutzeraccount aus.
+        Organisation. Sie wählen damit Ihr Benutzerkonto aus.
     </p>
 
     <button

--- a/shared/src/interfaces/collections.ts
+++ b/shared/src/interfaces/collections.ts
@@ -187,8 +187,9 @@ export namespace Marketplace {
                     z.object({
                         id: organisationIdSchema,
                         name: z.string(),
-                        owner: z.boolean(),
+                        isOwner: z.boolean(),
                         personalOrganisationOf: z.string().nullable(),
+                        personalOrganisationOfName: z.string().nullable(),
                     })
                 ),
             }),


### PR DESCRIPTION
### Summary

Resolves #1682. Shows user accounts as collection members instead of only their (equally named) organizations.

### PR Checklist

Please make sure to fulfill the following conditions before marking this PR ready for review:

- [x] If this PR adds or changes features or fixes bugs, this has been added to the changelog.
- [x] If this PR adds or changes features, the related documentation has been updated.
- [x] If this PR adds new actions or other ways to alter the state, [test scenarios](https://github.com/hpi-sam/fuesim-digital-public-test-scenarios) have been added.
- [x] By signing off my commits (`git commit -s`), I certify that I have read and adhere to the terms of the [Developer Certificate of Origin 1.1](https://developercertificate.org/) and license the code in this Pull Request under this projects license ([LICENSE-README.md](https://github.com/hpi-sam/fuesim-digital/blob/dev/LICENSE-README.md)).
- [x] If I have used third party code that requires attribution, I have mentioned it in the code and updated [inspired-by-or-copied-from-list.html](https://github.com/hpi-sam/fuesim-digital/blob/dev/inspired-by-or-copied-from-list.html).
